### PR TITLE
Add ca-certificates to images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ EXPOSE 4200
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 RUN apt-get update && apt-get install -qqy --no-install-recommends \
+    ca-certificates \
     dumb-init \
     git \
     build-essential \

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -43,6 +43,7 @@ EXPOSE 4200
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 RUN apt-get update && apt-get install -qqy --no-install-recommends \
+    ca-certificates \
     dumb-init \
     git \
     build-essential \

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -43,6 +43,7 @@ EXPOSE 4200
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 RUN apt-get update && apt-get install -qqy --no-install-recommends \
+    ca-certificates \
     dumb-init \
     git \
     build-essential \


### PR DESCRIPTION
I was facing an issue while using this image for CI. Basically I was pulling a package as a Git repo and getting this error

```
fatal: unable to access 'https://gitlab.com/': Problem with the SSL CA cert (path? access rights?)
```

Somehow this started happening around the beginning of January... I don't know what changes made it so.
Upon checking, the CA store was empty, so this fixes that.