### PR TITLE
Set Node Version Explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #alternative to reduce size instead of alpine, but does not
 #include build tools for native compilation of npm packages
 #we therefore add gcc
-FROM node:lts-slim
+FROM node:16-slim
 
 #MAINTAINER trion development GmbH "info@trion.de"
 LABEL maintainer="trion development GmbH <docker-image@trion.de>"

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -16,7 +16,7 @@ RUN apk add curl && curl -L ${QEMU_URL} | tar zxvf - -C . --strip-components 1
 #alternative to reduce size instead of alpine, but does not
 #include build tools for native compilation of npm packages
 #we therefore add gcc
-FROM arm32v7/node:lts-slim
+FROM arm32v7/node:16-slim
 
 # Add QEMU
 COPY --from=builder qemu-arm-static /usr/bin

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -16,7 +16,7 @@ RUN apk add curl && curl -L ${QEMU_URL} | tar zxvf - -C . --strip-components 1
 #alternative to reduce size instead of alpine, but does not
 #include build tools for native compilation of npm packages
 #we therefore add gcc
-FROM arm64v8/node:lts-slim
+FROM arm64v8/node:16-slim
 
 # Add QEMU
 COPY --from=builder qemu-aarch64-static /usr/bin

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Docker image for Angular CLI to use as build container.
 
 Image on DockerHub: https://hub.docker.com/r/trion/ng-cli/
 
-Currently this image uses Node LTS (16, npm 8) and node:lts-slim as base distribution.
+Currently this image uses Node LTS (16, npm 8) and node:16-slim as base distribution.
 
 The AngularCLI analytics feature is disabled by default to avoid problems in CI environments.
 If you want to opt-in, set the `NG_CLI_ANALYTICS` environment variable to an empty value.


### PR DESCRIPTION
[As of a few days ago, Node LTS is version 18](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#18.12.0).

Since `trion/ng-cli:14.2.7` is based on `node:lts-slim` now Node 18, which is **not** compatible with ng cli 💣

I'm not sure if you can remove / republish 14.2.7 onto docker hub